### PR TITLE
feat: Define GetCommand function for actionlint

### DIFF
--- a/ale_linters/yaml/actionlint.vim
+++ b/ale_linters/yaml/actionlint.vim
@@ -1,3 +1,15 @@
+function! ale_linters#yaml#actionlint#GetCommand(buffer) abort
+    " Only execute actionlint on YAML files in /.github/ paths.
+    if expand('#' . a:buffer . ':p') !~# '\v[/\\]\.github[/\\]'
+        return ''
+    endif
+
+    let l:options = ale#Var(a:buffer, 'yaml_actionlint_options')
+
+    " The --stdin-filename option is necessary to read the .github/actionlint.yaml file.
+    return 'actionlint -stdin-filename %s -format "{{json .}}"' . ale#Pad(l:options) . ' - '
+endfunction
+
 function! ale_linters#yaml#actionlint#Handle(buffer, lines) abort
     let l:output = []
 
@@ -17,9 +29,7 @@ endfunction
 call ale#linter#Define('yaml', {
 \   'name': 'actionlint',
 \   'executable': {b -> expand('#' . b . ':p:h') =~? '\.github/workflows$' ? 'actionlint' : ''},
-\   'command': 'actionlint -format "{{json .}}" - < %s',
+\   'command': function('ale_linters#yaml#actionlint#GetCommand'),
 \   'callback': 'ale_linters#yaml#actionlint#Handle',
 \   'output_stream': 'stdout',
 \})
-
-


### PR DESCRIPTION
- `g:ale_yaml_actionlint_options` is used to set the options for actionlint.
- `.github/actionlint.yaml` is correctly loaded
